### PR TITLE
version bump `trash` to `3.0.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,9 +914,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "trash"
-version = "3.0.1"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b2a127810fceb959593bbc6c7b8e0282c2d318d76f0749252197c52a1dd0c"
+checksum = "af3663fb8f476d674b9c61d1d2796acec725bef6bec4b41402a904252a25971e"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "trash"
 clap_mangen = "0.2.9"
 clap_complete = "4.1.4"
 anyhow = { version = "1.0.68", features = ["backtrace"] }
-trash = "3.0.2"
+trash = "3.0.6"
 chrono = "0.4.23"
 chrono-humanize = "0.2.1"
 lscolors = { version = "0.13.0", features = ["crossterm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "trash"
 clap_mangen = "0.2.9"
 clap_complete = "4.1.4"
 anyhow = { version = "1.0.68", features = ["backtrace"] }
-trash = "3.0.1"
+trash = "3.0.2"
 chrono = "0.4.23"
 chrono-humanize = "0.2.1"
 lscolors = { version = "0.13.0", features = ["crossterm"] }


### PR DESCRIPTION
Version bumping `trash` fixes issue #97.

There **_may_** still be a symlink-related bug somewhere due to [this](https://github.com/oberblastmeister/trashy/blob/5e565853148658e63deada6a3e378506cfb2ee52/src/app/command/list.rs#L263) check for whether a path exists, which might need a fix similar to [trash-rs#68](https://github.com/Byron/trash-rs/pull/68).  Having said that, I can't find an actual issue, so maybe there is one.