### PR TITLE
Rename executable to trashy (#104)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,12 +62,12 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            mv "target/${{ matrix.target }}/release/trash.exe" "trash-${{ matrix.target }}.exe"
-            echo "ASSET=trash-${{ matrix.target }}.exe" >> $GITHUB_ENV
+            mv "target/${{ matrix.target }}/release/trashy.exe" "trashy-${{ matrix.target }}.exe"
+            echo "ASSET=trashy-${{ matrix.target }}.exe" >> $GITHUB_ENV
           else
-            mv "target/${{ matrix.target }}/release/trash" "trash"
-            tar czf trash-${{ matrix.target }}.tar.gz trash
-            echo "ASSET=trash-${{ matrix.target }}.tar.gz" >> $GITHUB_ENV
+            mv "target/${{ matrix.target }}/release/trashy" "trashy"
+            tar czf trashy-${{ matrix.target }}.tar.gz trashy
+            echo "ASSET=trashy-${{ matrix.target }}.tar.gz" >> $GITHUB_ENV
           fi
 
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- `trash restore` will pull up an interactive prompt if no arguments are given
+- `trashy restore` will pull up an interactive prompt if no arguments are given
 - upgrade to clap v4
 
 ## Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.62"
 
 [[bin]]
 path = "src/main.rs"
-name = "trash"
+name = "trashy"
 
 [dependencies]
 clap_mangen = "0.2.9"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quick links:
 
 ## Features
 
-- easy to use, just run `trash PATH`
+- easy to use, just run `trashy put PATH`
 - recursive by default, without having the issues
 - beautiful output
     - colorized paths (similar to *fd*)
@@ -30,28 +30,28 @@ Quick links:
 ### Trash a path
 
 ```bash
-$ trash first second third
+$ trashy first second third
 ```
 
 This is just sugar for 
 
 ```bash
-$ trash put first second third
+$ trashy put first second third
 ```
 
 ### List items in the trash
 
 ```bash
-$ trash list
+$ trashy list
 ```
 
 ### Restore or empty some files
 
 ```bash
-$ trash restore first second
+$ trashy restore first second
 ```
 ```bash
-$ trash empty first second third
+$ trashy empty first second third
 ```
 
 The `restore` and `empty` subcommands both take very similar arguments and flags.
@@ -63,11 +63,11 @@ Use the `-m` option to interpret them differently.
 ### Restore or empty all files
 
 ```bash
-$ trash restore --all
+$ trashy restore --all
 ```
 
 ```bash
-$ trash empty --all
+$ trashy empty --all
 ```
 
 ## Integrations
@@ -77,13 +77,13 @@ $ trash empty --all
 Restore with fzf
 
 ```bash
-trash list | fzf --multi | awk '{$1=$1;print}' | rev | cut -d ' ' -f1 | rev | xargs trash restore --match=exact --force
+trashy list | fzf --multi | awk '{$1=$1;print}' | rev | cut -d ' ' -f1 | rev | xargs trashy restore --match=exact --force
 ```
 
 Empty with fzf
 
 ```bash
-trash list | fzf --multi | awk '{$1=$1;print}' | rev | cut -d ' ' -f1 | rev | xargs trash empty --match=exact --force
+trashy list | fzf --multi | awk '{$1=$1;print}' | rev | cut -d ' ' -f1 | rev | xargs trashy empty --match=exact --force
 ```
 
 ## Installation
@@ -136,7 +136,7 @@ Time (abs ≡):        65.849 s               [User: 54.383 s, System: 11.370 s]
 Now with `trashy`
 
 ```
-hyperfine -M 1 'fd -t f --threads 1 -x trash put'
+hyperfine -M 1 'fd -t f --threads 1 -x trashy put'
 ```
 
 ```
@@ -158,7 +158,7 @@ Range (min … max):   375.9 ms … 412.0 ms    10 runs
 
 
 ```
-hyperfine 'trash list'
+hyperfine 'trashy list'
 ```
 
 ```
@@ -174,9 +174,9 @@ Range (min … max):   175.6 ms … 181.0 ms    16 runs
 
 No, see this [issue](https://github.com/Byron/trash-rs/issues/8)
 
-### Should I alias rm='trash put'?
+### Should I alias rm='trashy put'?
 
-You should not. The alias will not be present on other systems and habits are really hard to break. An alternative is to alias `trash put` to `rt` or `tp`.
+You should not. The alias will not be present on other systems and habits are really hard to break. An alternative is to alias `trashy put` to `rt` or `tp`.
 
 ## License
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use command::Command;
     version,
     about,
     long_about = None,
-    after_help = "Note: `trash -h` prints a short and concise overview while `trash --help` gives all \
+    after_help = "Note: `trashy -h` prints a short and concise overview while `trashy --help` gives all \
                  details.",
 )]
 pub struct Args {

--- a/src/app/command/completions.rs
+++ b/src/app/command/completions.rs
@@ -13,7 +13,7 @@ pub struct Args {
 
 impl Args {
     pub fn run(&self) -> Result<()> {
-        clap_complete::generate(self.shell, &mut app::Args::command(), "trash", &mut io::stdout());
+        clap_complete::generate(self.shell, &mut app::Args::command(), "trashy", &mut io::stdout());
         Ok(())
     }
 }

--- a/src/app/command/list.rs
+++ b/src/app/command/list.rs
@@ -46,7 +46,7 @@ pub struct QueryArgs {
     /// This option puts the oldest trash item at the bottom.
     /// This will also affect 'empty' or 'restore' if used in either command.
     /// Examples:
-    /// 'trash empty --rev -n=10' will delete 10 oldest trash items are deleted.
+    /// 'trashy empty --rev -n=10' will delete 10 oldest trash items are deleted.
     #[arg(long, verbatim_doc_comment)]
     pub rev: bool,
 
@@ -54,8 +54,8 @@ pub struct QueryArgs {
     ///
     /// This will also affect 'empty' or 'restore' if used in either command.
     /// Examples:
-    /// 'trash list -n=10' will list the ten newest trashed items.
-    /// 'trash restore -n=10' will list restore the ten newest trashed items.
+    /// 'trashy list -n=10' will list the ten newest trashed items.
+    /// 'trashy restore -n=10' will list restore the ten newest trashed items.
     #[arg(short = 'n', long = "max", verbatim_doc_comment)]
     pub max: Option<NonZeroU32>,
 }

--- a/src/app/command/utils.rs
+++ b/src/app/command/utils.rs
@@ -37,7 +37,7 @@ pub struct Ranges {
     /// Filter by ranges
     ///
     /// This should be used to restore specific items.
-    /// To find the ranges, look at the 'i' column in the table shown by 'trash list'.
+    /// To find the ranges, look at the 'i' column in the table shown by 'trashy list'.
     /// The option is called '--ranges' but you can also use individual indices by just typing out the number.
     /// Ranges are zero based, inclusive at the start, and exclusive at the end, just like rust ranges.
     /// Examples:

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -62,9 +62,9 @@ pub struct FilterArgs {
     /// This will filter using a pattern type specified in '--match'.
     /// Using <PATTERNS> and '--match' gives the same effect as passing one of the pattern options explicitly.
     /// So for example
-    /// trash restore '~/projects/**' '~/builds/**' --match=glob
+    /// trashy restore '~/projects/**' '~/builds/**' --match=glob
     /// is the same as
-    /// trash restore --glob='~/project/**' --glob='~/builds/**'
+    /// trashy restore --glob='~/project/**' --glob='~/builds/**'
     #[arg(verbatim_doc_comment)]
     pub patterns: Vec<String>,
 


### PR DESCRIPTION
Since trashy no longer supports `trash <PATH> ...` and has given up on being a drop-in trash-cli replacement, the executable name `trash` is only a hinderance to greater adoption because it conflicts with the trash-cli executable of the same name. Giving the executable a unique name allows both programs to be installed without issue and also allows programs that wish to shell out to external commands for trashing files to support trashy by simply checking if an executable named `trashy` is present. Before this change, these programs had to check the output of the user's `trash` command to determine if it was from trash-cli or trashy.

Fixes #104 