### PR TITLE
Fix typo in README command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ paru -S trashy
 ### Using Nix
 
 ```bash
-niv-env -i trashy
+nix-env -i trashy
 ```
 
 Or if you have flakes enabled:


### PR DESCRIPTION
I got a `command not found` when copying the NIX instriction.